### PR TITLE
Datamodel and -struct seperation, and updated manager implementation  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
-.old
+# Local only
 .vscode
-sdl2
 build
+
+# Deprecated
+.old
+todo
+
+# Extras
+sdl2
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     "${CMAKE_SOURCE_DIR}/src/core"
     "${CMAKE_SOURCE_DIR}/src/debug"
     "${CMAKE_SOURCE_DIR}/src/data"
+    "${CMAKE_SOURCE_DIR}/src/models"
     "${CMAKE_SOURCE_DIR}/src/state"
     "${CMAKE_SOURCE_DIR}/src/state/managers"
     "${CMAKE_SOURCE_DIR}/src/rendering"

--- a/compile
+++ b/compile
@@ -1,6 +1,6 @@
 ninja > output-build.txt 2>&1
 
 echo
-echo Compilation finished 
-echo See \"build/output-build.txt\" for details
+echo Requested job finished. 
+echo -> See \"build/output-build.txt\" for details.
 

--- a/compile
+++ b/compile
@@ -2,5 +2,5 @@ ninja > output-build.txt 2>&1
 
 echo
 echo Requested job finished. 
-echo -> See \"build/output-build.txt\" for details.
+echo "-> See \"build/output-build.txt\" for details."
 

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -272,7 +272,6 @@ void Application::loadBeatmap() {
 
     // Load audio                                                                       - AudioPlayer
     if (audioPlayer) [[likely]] {
-        // | audioPlayer->load(beatmapManager->active().audioPath());
         audioPlayer->load(beatmapManager->active().audioPath());
 
         // Load the audio stream by setting playback at 0 ms and immediately pausing

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -272,6 +272,7 @@ void Application::loadBeatmap() {
 
     // Load audio                                                                       - AudioPlayer
     if (audioPlayer) [[likely]] {
+        // | audioPlayer->load(beatmapManager->active().audioPath());
         audioPlayer->load(beatmapManager->active().audioPath());
 
         // Load the audio stream by setting playback at 0 ms and immediately pausing

--- a/src/data/beatmap.h
+++ b/src/data/beatmap.h
@@ -12,9 +12,10 @@ namespace OsuParser::Beatmap {
 // * Struct to hold extra beatmap info. The only reason this exists is to prevent 
 // * passing the entire beatmap class around as it can potentially be very heavy. 
 // * This struct should only contain the absolute minimum info needed.
+// TODO: Refactor to not use audioPath() as a function, but instead store the full audio path,
+//     : as it is more efficient. (See `audioPath()` in `src/models/beatmap.cpp` for details)
 struct BeatmapExData {
-    // Data
-    // | OsuParser::Beatmap::Beatmap* beatmap;                          
+    // Data           
     std::filesystem::path location;                                                     // Directory of the beatmap file
     std::string audioFilename;                                                          // Filename of the beatmap's audio file (extracted from the beatmap file, not the path)
     size_t index;

--- a/src/data/beatmap.h
+++ b/src/data/beatmap.h
@@ -5,15 +5,18 @@
 
 // Forward declarations instead of including the full parser
 namespace OsuParser::Beatmap {
-    class Beatmap;
+   class Beatmap;
 }
 
 
-// * Struct to hold extra beatmap info
+// * Struct to hold extra beatmap info. The only reason this exists is to prevent 
+// * passing the entire beatmap class around as it can potentially be very heavy. 
+// * This struct should only contain the absolute minimum info needed.
 struct BeatmapExData {
     // Data
-    OsuParser::Beatmap::Beatmap* beatmap;
-    std::filesystem::path location;                                                     // Directory of the beatmap file                                  
+    // | OsuParser::Beatmap::Beatmap* beatmap;                          
+    std::filesystem::path location;                                                     // Directory of the beatmap file
+    std::string audioFilename;                                                          // Filename of the beatmap's audio file (extracted from the beatmap file, not the path)
     size_t index;
 
     // Getters

--- a/src/data/skin.h
+++ b/src/data/skin.h
@@ -62,6 +62,8 @@ struct SkinConfig : public SkinElement {};
 
 
 // * Skin data structs
+// ! NOTE: These structs have default initializers that ensure no NULL values are present.
+// !       This implies that a variable with an empty initializer value still contains data!
 namespace SkinData {
 // * RESOURCES
 // // #include "../resources/skins/legacy.h"                                                  // Import legacy skin resources within the  
@@ -624,28 +626,3 @@ struct Config {
 } // namespace SkinData
 
 
-
-// * Skin class
-class Skin {
-private:
-    // Program metadata
-    SkinExData data;
-
-    // Actual skin data
-    SkinData::Samples samples;
-    SkinData::Sprites sprites;
-    SkinData::Config config; 
-
-public:
-//     Skin();
-//     ~Skin();
-
-//     // Load skin from path
-//     bool loadFromPath(const std::filesystem::path& path);
-
-    // Getters
-    const SkinExData&           getData()       const { return data;    }
-    const SkinData::Samples&    getSamples()    const { return samples; }
-    const SkinData::Sprites&    getSprites()    const { return sprites; }
-    const SkinData::Config&     getConfig()     const { return config;  }
-};

--- a/src/models/beatmap.cpp
+++ b/src/models/beatmap.cpp
@@ -1,0 +1,28 @@
+#include "beatmap.h"
+
+// // #include <osu!parser/Parser/Beatmap.hpp>
+
+
+#define NOT_SET 0                                                                       // ! Can't be negative as it's unsigned
+
+
+
+// * Constructors & destructor
+Beatmap::Beatmap(const std::string& path) : OsuParser::Beatmap::Beatmap(path) {
+    // Program metadata
+    data.location = std::filesystem::path(path).parent_path();                          // Directory of the beatmap
+    data.audioFilename = General.AudioFilename;                                         // Filename of the beatmap's audio file (extracted from the beatmap file, not the path)
+    data.index = NOT_SET;                                                               // ? Index is set by the BeatmapManager     
+}
+
+Beatmap::~Beatmap() = default;
+
+
+
+// * BeatmapExData function definitions
+// ? I kept this definition here, and not in "src/data/beatmap.h" to avoid including the parser in that file
+std::filesystem::path BeatmapExData::audioPath() const {
+    // | if (!beatmap) { return {}; }                                                        // No active beatmap
+    // | return data.location / General.AudioFilename;
+    return location / audioFilename;
+}

--- a/src/models/beatmap.cpp
+++ b/src/models/beatmap.cpp
@@ -21,8 +21,8 @@ Beatmap::~Beatmap() = default;
 
 // * BeatmapExData function definitions
 // ? I kept this definition here, and not in "src/data/beatmap.h" to avoid including the parser in that file
+// TODO: Refactor to not be a function, but a member variable that's set in the constructor, as this is 
+//     : more efficient. We keep this for now, as it's unsure if we need the location for anything else
 std::filesystem::path BeatmapExData::audioPath() const {
-    // | if (!beatmap) { return {}; }                                                        // No active beatmap
-    // | return data.location / General.AudioFilename;
     return location / audioFilename;
 }

--- a/src/models/beatmap.h
+++ b/src/models/beatmap.h
@@ -5,26 +5,46 @@
 
 #pragma once
 
+#include <cmath>
+#include <memory>
+#include <osu!parser/Parser/Beatmap.hpp>
+
 #include "../data/beatmap.h"
 
+// ? NOTE TO SELF: Ensure the beatmap manager interacts with this model, and not directly with the parser's beatmap struct
 
 
 // * Beatmap model 
-class Beatmap {
+class Beatmap : public OsuParser::Beatmap::Beatmap {
 private:
-    // Program metadata
+    // * Program metadata
     BeatmapExData data;
 
-    // Actual beatmap data
-    // TODO: REFACTOR THIS TO BE THE BEATMAP SECTIONS PARSED BY THE PARSER!
-    // TODO: BeatmapData;
-    // TODO: BeatmapData;
-    // TODO: BeatmapData; 
-
 public:
+    // * Constructors & destructor
+    Beatmap(const std::string& path);
+    ~Beatmap();
 
-    // Getters
-    const BeatmapExData&           getData()       const { return data;    }
+    // * Actual beatmap data
+    /*// ? Inherited from `OsuParser::Beatmap::Beatmap`
+    // Version
+        std::int32_t Version = 14;
+    // Sections
+        Sections::General::GeneralSection General;
+        Sections::Metadata::MetadataSection Metadata;
+        Sections::Editor::EditorSection Editor;
+        Sections::Difficulty::DifficultySection Difficulty;
+        Sections::Colour::ColourSection Colours;
+        Sections::Variable::VariableSection Variables;
+    // Objects
+        Objects::TimingPoint::TimingPoints TimingPoints;
+        Objects::HitObject::HitObjects HitObjects;
+        Objects::Event::Events Events;
+    */
+
+    // * Getters
+    std::filesystem::path audioPath() const;
+    const BeatmapExData& ExData() const { return data; }
     // TODO: REFACTOR THIS TO RETURN THE BEATMAP SECTIONS PARSED BY THE PARSER!
     // TODO: const SkinData::Samples&    getSamples()    const { return samples; }
     // TODO: const SkinData::Sprites&    getSprites()    const { return sprites; }

--- a/src/models/beatmap.h
+++ b/src/models/beatmap.h
@@ -1,0 +1,32 @@
+// * NOTICE
+//  This file contains the Beatmap datamodel, which is an instance of a beatmap. This class is accessed by
+//  the beatmap manager in `state/beatmap.h` and is responsible for managing the lifecycle of a beatmap 
+//  instance. The actual data structs and containers for a beatmap's data is defined in `data/beatmap.h`
+
+#pragma once
+
+#include "../data/beatmap.h"
+
+
+
+// * Beatmap model 
+class Beatmap {
+private:
+    // Program metadata
+    BeatmapExData data;
+
+    // Actual beatmap data
+    // TODO: REFACTOR THIS TO BE THE BEATMAP SECTIONS PARSED BY THE PARSER!
+    // TODO: BeatmapData;
+    // TODO: BeatmapData;
+    // TODO: BeatmapData; 
+
+public:
+
+    // Getters
+    const BeatmapExData&           getData()       const { return data;    }
+    // TODO: REFACTOR THIS TO RETURN THE BEATMAP SECTIONS PARSED BY THE PARSER!
+    // TODO: const SkinData::Samples&    getSamples()    const { return samples; }
+    // TODO: const SkinData::Sprites&    getSprites()    const { return sprites; }
+    // TODO: const SkinData::Config&     getConfig()     const { return config;  }
+};

--- a/src/models/beatmap.h
+++ b/src/models/beatmap.h
@@ -26,17 +26,17 @@ public:
     ~Beatmap();
 
     // * Actual beatmap data
-    /*// ? Inherited from `OsuParser::Beatmap::Beatmap`
-    // Version
+    /*// (Members inherited from: `OsuParser::Beatmap::Beatmap`)
+    // ? Version
         std::int32_t Version = 14;
-    // Sections
+    // ? Sections
         Sections::General::GeneralSection General;
         Sections::Metadata::MetadataSection Metadata;
         Sections::Editor::EditorSection Editor;
         Sections::Difficulty::DifficultySection Difficulty;
         Sections::Colour::ColourSection Colours;
         Sections::Variable::VariableSection Variables;
-    // Objects
+    // ? Objects
         Objects::TimingPoint::TimingPoints TimingPoints;
         Objects::HitObject::HitObjects HitObjects;
         Objects::Event::Events Events;
@@ -45,8 +45,4 @@ public:
     // * Getters
     std::filesystem::path audioPath() const;
     const BeatmapExData& ExData() const { return data; }
-    // TODO: REFACTOR THIS TO RETURN THE BEATMAP SECTIONS PARSED BY THE PARSER!
-    // TODO: const SkinData::Samples&    getSamples()    const { return samples; }
-    // TODO: const SkinData::Sprites&    getSprites()    const { return sprites; }
-    // TODO: const SkinData::Config&     getConfig()     const { return config;  }
 };

--- a/src/models/skin.h
+++ b/src/models/skin.h
@@ -1,0 +1,36 @@
+// * NOTICE
+//  This file contains the Skin datamodel, which is an instance of a skin. This class is accessed 
+//  by the skin manager in `state/skin.h` and is responsible for managing the lifecycle of a skin 
+//  instance. The actual data structs and containers for a skin's data is defined in `data/skin.h`
+
+#pragma once
+
+#include "../data/skin.h"
+
+
+
+// * Skin model 
+class Skin {
+private:
+    // Program metadata
+    SkinExData data;
+
+    // Actual skin data
+    // ! NOTICE: ALL of these members contains intialized data. THEY ARE NOT NULL!  (see `data/skin.h::SkinData` for details)
+    SkinData::Samples samples;                                                          
+    SkinData::Sprites sprites;                             
+    SkinData::Config config;                  
+
+public:
+//     Skin();
+//     ~Skin();
+
+//     // Load skin from path
+//     bool loadFromPath(const std::filesystem::path& path);
+
+    // Getters
+    const SkinExData&           getData()       const { return data;    }
+    const SkinData::Samples&    getSamples()    const { return samples; }
+    const SkinData::Sprites&    getSprites()    const { return sprites; }
+    const SkinData::Config&     getConfig()     const { return config;  }
+};

--- a/src/state/beatmap.cpp
+++ b/src/state/beatmap.cpp
@@ -76,16 +76,22 @@ void BeatmapManager::loadBeatmap() {
     // Load the selected beatmap
     std::cout << "Loading beatmap: " << path << "\n";
 
-    if (loadFromFile(path)) {
-        std::cout << "Beatmap loaded successfully\n";
+    if (!loadFromFile(path)) [[unlikely]] {
+        std::cerr << "Failed to load beatmap\n";                                        // Ensure we don't assume beatmap loaded
+        return;
     }
 
-    // Update activeBeatmap struct
-    activeBeatmap.beatmap = activeBeatmapPtr();
-    activeBeatmap.location = fs::path(path).parent_path();
-    activeBeatmap.index = 0;                                                            // When loading a new map, it is always at index 0
+    std::cout << "Beatmap loaded successfully\n";
+    
 
-    // todo
+    // Update activeBeatmap struct
+    // | activeBeatmap.beatmap = activeBeatmapPtr();
+    // | activeBeatmap.location = fs::path(path).parent_path();
+    // | activeBeatmap.index = 0;                                                            // When loading a new map, it is always at index 0
+    activeBeatmap = (maps.front())->ExData();                                           // | TEST
+
+
+    // todo ?
     // Notify application of new beatmap loaded
     std::cout << "Notifying application of loaded beatmap (TODO)\n";
 
@@ -140,7 +146,8 @@ void BeatmapManager::addBeatmap() {
 [[nodiscard]] bool BeatmapManager::loadFromFile(const std::string& path, bool discardIfDuplicate) {
     try {
         // Parse beatmap
-        auto beatmap = std::make_unique<OsuParser::Beatmap::Beatmap>(path);
+        // | auto beatmap = std::make_unique<OsuParser::Beatmap::Beatmap>(path);
+        auto beatmap = std::make_unique<Beatmap>(path);                                 // | TEST
         
         // Check for duplicates if requested
         if (discardIfDuplicate) {
@@ -166,7 +173,31 @@ void BeatmapManager::unloadAll() {
     maps.clear();
 }
 
-bool BeatmapManager::isAlreadyLoaded(const OsuParser::Beatmap::Beatmap& beatmap) const {
+// |bool BeatmapManager::isAlreadyLoaded(const OsuParser::Beatmap::Beatmap& beatmap) const {
+// |    // ? Check 1: If it has a BeatmapID, check by ID (submitted maps)
+// |    if (beatmap.Metadata.BeatmapID != "0") {
+// |        return std::any_of(maps.begin(), maps.end(),
+// |            [&beatmap](const auto& existing) {
+// |                return existing->Metadata.BeatmapID == beatmap.Metadata.BeatmapID;
+// |            }
+// |        );
+// |    }
+
+// |    // ? Check 2: Check by metadata combination (Artist + Title + Creator + Difficulty)
+// |    return std::any_of(maps.begin(), maps.end(),
+// |        [&beatmap](const auto& existing) {
+// |            return existing->Metadata.Artist == beatmap.Metadata.Artist &&
+// |                   existing->Metadata.Title == beatmap.Metadata.Title &&
+// |                   existing->Metadata.Creator == beatmap.Metadata.Creator &&
+// |                   existing->Metadata.Version == beatmap.Metadata.Version;
+// |        }
+// |    );
+
+// |    // TODO:
+// |    // ? Alternative Check 3: Somehow compare the entire file contents (only timing points + hit objects) quickly
+// |}
+
+bool BeatmapManager::isAlreadyLoaded(const Beatmap& beatmap) const {
     // ? Check 1: If it has a BeatmapID, check by ID (submitted maps)
     if (beatmap.Metadata.BeatmapID != "0") {
         return std::any_of(maps.begin(), maps.end(),
@@ -190,9 +221,11 @@ bool BeatmapManager::isAlreadyLoaded(const OsuParser::Beatmap::Beatmap& beatmap)
     // ? Alternative Check 3: Somehow compare the entire file contents (only timing points + hit objects) quickly
 }
 
+
 // TODO: FIX THIS FUNCTION TO ACTUALLY GET THE ACTIVE BEATMAP POINTER BASED ON THE CURRENTLY SELECTED ACTIVE INDEX (see loadBeatmap and addBeatmap for function requirements)
 // Internal helper to get the active beatmap pointer
-OsuParser::Beatmap::Beatmap* BeatmapManager::activeBeatmapPtr() const {
+// | OsuParser::Beatmap::Beatmap* BeatmapManager::activeBeatmapPtr() const {
+Beatmap* BeatmapManager::activeBeatmapPtr() const {
     return maps.empty() ? nullptr : maps.front().get();
 }
 
@@ -203,13 +236,4 @@ OsuParser::Beatmap::Beatmap* BeatmapManager::activeBeatmapPtr() const {
 // //     }
 // // }
 
-
-
-
-// * BeatmapExData function definitions
-// ? I kept this definition here, and not in "src/data/beatmap.h" to avoid including the parser in that file
-std::filesystem::path BeatmapExData::audioPath() const {
-    if (!beatmap) { return {}; }                                                        // No active beatmap
-    return location / beatmap->General.AudioFilename;
-}
 

--- a/src/state/beatmap.cpp
+++ b/src/state/beatmap.cpp
@@ -84,11 +84,8 @@ void BeatmapManager::loadBeatmap() {
     std::cout << "Beatmap loaded successfully\n";
     
 
-    // Update activeBeatmap struct
-    // | activeBeatmap.beatmap = activeBeatmapPtr();
-    // | activeBeatmap.location = fs::path(path).parent_path();
-    // | activeBeatmap.index = 0;                                                            // When loading a new map, it is always at index 0
-    activeBeatmap = (maps.front())->ExData();                                           // | TEST
+    // Update activeBeatmap struct         
+    activeBeatmap = (maps.front())->ExData();                                           
 
 
     // todo ?
@@ -146,8 +143,7 @@ void BeatmapManager::addBeatmap() {
 [[nodiscard]] bool BeatmapManager::loadFromFile(const std::string& path, bool discardIfDuplicate) {
     try {
         // Parse beatmap
-        // | auto beatmap = std::make_unique<OsuParser::Beatmap::Beatmap>(path);
-        auto beatmap = std::make_unique<Beatmap>(path);                                 // | TEST
+        auto beatmap = std::make_unique<Beatmap>(path);                                 
         
         // Check for duplicates if requested
         if (discardIfDuplicate) {
@@ -172,30 +168,6 @@ void BeatmapManager::addBeatmap() {
 void BeatmapManager::unloadAll() {
     maps.clear();
 }
-
-// |bool BeatmapManager::isAlreadyLoaded(const OsuParser::Beatmap::Beatmap& beatmap) const {
-// |    // ? Check 1: If it has a BeatmapID, check by ID (submitted maps)
-// |    if (beatmap.Metadata.BeatmapID != "0") {
-// |        return std::any_of(maps.begin(), maps.end(),
-// |            [&beatmap](const auto& existing) {
-// |                return existing->Metadata.BeatmapID == beatmap.Metadata.BeatmapID;
-// |            }
-// |        );
-// |    }
-
-// |    // ? Check 2: Check by metadata combination (Artist + Title + Creator + Difficulty)
-// |    return std::any_of(maps.begin(), maps.end(),
-// |        [&beatmap](const auto& existing) {
-// |            return existing->Metadata.Artist == beatmap.Metadata.Artist &&
-// |                   existing->Metadata.Title == beatmap.Metadata.Title &&
-// |                   existing->Metadata.Creator == beatmap.Metadata.Creator &&
-// |                   existing->Metadata.Version == beatmap.Metadata.Version;
-// |        }
-// |    );
-
-// |    // TODO:
-// |    // ? Alternative Check 3: Somehow compare the entire file contents (only timing points + hit objects) quickly
-// |}
 
 bool BeatmapManager::isAlreadyLoaded(const Beatmap& beatmap) const {
     // ? Check 1: If it has a BeatmapID, check by ID (submitted maps)
@@ -224,7 +196,6 @@ bool BeatmapManager::isAlreadyLoaded(const Beatmap& beatmap) const {
 
 // TODO: FIX THIS FUNCTION TO ACTUALLY GET THE ACTIVE BEATMAP POINTER BASED ON THE CURRENTLY SELECTED ACTIVE INDEX (see loadBeatmap and addBeatmap for function requirements)
 // Internal helper to get the active beatmap pointer
-// | OsuParser::Beatmap::Beatmap* BeatmapManager::activeBeatmapPtr() const {
 Beatmap* BeatmapManager::activeBeatmapPtr() const {
     return maps.empty() ? nullptr : maps.front().get();
 }

--- a/src/state/beatmap.h
+++ b/src/state/beatmap.h
@@ -8,7 +8,7 @@
 
 // // #include <SDL.h>
 #include "manager.h"
-#include "../data/beatmap.h"
+#include "../models/beatmap.h"
 
 
 // * BeatmapManager: Manages loading, storing, and accessing beatmaps
@@ -18,15 +18,20 @@ private:
     // // SDL_Window* window;
 
     // State
-    std::vector<std::unique_ptr<OsuParser::Beatmap::Beatmap>> maps;
+    // | std::vector<std::unique_ptr<OsuParser::Beatmap::Beatmap>> maps;
+    std::vector<std::unique_ptr<Beatmap>> maps;                                         // | TEST
     // // size_t activeIndex = 0;                                                             // We implement such that this can be a different value than 0, but it shouldn't be anything else than 0 for now
-    BeatmapExData activeBeatmap;                                                        // This struct should follow the lifecycle of the entire  
-                                                                                        // manager. This variable should always be valid if there
-                                                                                        // is at least one map loaded. Only it's members change.                   
+    // | BeatmapExData activeBeatmap;                                                   // This struct should follow the lifecycle of the entire 
+    // |                                                                                // manager. This variable should always be valid if there
+    // |                                                                                // is at least one map loaded. Only it's members change. 
 
+    BeatmapExData activeBeatmap;                                                             
+    
     // Helpers
-    OsuParser::Beatmap::Beatmap* activeBeatmapPtr() const;
-    bool isAlreadyLoaded(const OsuParser::Beatmap::Beatmap& beatmap) const;
+    // | OsuParser::Beatmap::Beatmap* activeBeatmapPtr() const;
+    Beatmap* activeBeatmapPtr() const;                                                  // | TEST
+    // | bool isAlreadyLoaded(const OsuParser::Beatmap::Beatmap& beatmap) const;
+    bool isAlreadyLoaded(const Beatmap& beatmap) const;                                 // | TEST
     [[nodiscard]] bool loadFromFile(const std::string& path, bool discardIfDuplicate = false);                                         
 
     // // #ifdef _WIN32
@@ -44,7 +49,9 @@ public:
     void unloadAll();
 
     // Getters
-    const std::vector<std::unique_ptr<OsuParser::Beatmap::Beatmap>>& all() const { return maps; }
+    // | const std::vector<std::unique_ptr<OsuParser::Beatmap::Beatmap>>& all() const { return maps; }
+    const std::vector<std::unique_ptr<Beatmap>>& all() const { return maps; }           // | TEST
+    // | const BeatmapExData& active() const { return activeBeatmap; }
     const BeatmapExData& active() const { return activeBeatmap; }
     const bool hasActive() const { return !maps.empty(); }
 

--- a/src/state/beatmap.h
+++ b/src/state/beatmap.h
@@ -18,20 +18,15 @@ private:
     // // SDL_Window* window;
 
     // State
-    // | std::vector<std::unique_ptr<OsuParser::Beatmap::Beatmap>> maps;
-    std::vector<std::unique_ptr<Beatmap>> maps;                                         // | TEST
+    std::vector<std::unique_ptr<Beatmap>> maps;                                        
     // // size_t activeIndex = 0;                                                             // We implement such that this can be a different value than 0, but it shouldn't be anything else than 0 for now
-    // | BeatmapExData activeBeatmap;                                                   // This struct should follow the lifecycle of the entire 
-    // |                                                                                // manager. This variable should always be valid if there
-    // |                                                                                // is at least one map loaded. Only it's members change. 
+    BeatmapExData activeBeatmap;                                                   // This struct should follow the lifecycle of the entire 
+                                                                                   // manager. This variable should always be valid if there
+                                                                                   // is at least one map loaded. Only it's members change. 
 
-    BeatmapExData activeBeatmap;                                                             
-    
     // Helpers
-    // | OsuParser::Beatmap::Beatmap* activeBeatmapPtr() const;
-    Beatmap* activeBeatmapPtr() const;                                                  // | TEST
-    // | bool isAlreadyLoaded(const OsuParser::Beatmap::Beatmap& beatmap) const;
-    bool isAlreadyLoaded(const Beatmap& beatmap) const;                                 // | TEST
+    Beatmap* activeBeatmapPtr() const;                                                 
+    bool isAlreadyLoaded(const Beatmap& beatmap) const;                                
     [[nodiscard]] bool loadFromFile(const std::string& path, bool discardIfDuplicate = false);                                         
 
     // // #ifdef _WIN32
@@ -49,9 +44,7 @@ public:
     void unloadAll();
 
     // Getters
-    // | const std::vector<std::unique_ptr<OsuParser::Beatmap::Beatmap>>& all() const { return maps; }
-    const std::vector<std::unique_ptr<Beatmap>>& all() const { return maps; }           // | TEST
-    // | const BeatmapExData& active() const { return activeBeatmap; }
+    const std::vector<std::unique_ptr<Beatmap>>& all() const { return maps; }
     const BeatmapExData& active() const { return activeBeatmap; }
     const bool hasActive() const { return !maps.empty(); }
 

--- a/src/state/skin.h
+++ b/src/state/skin.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "manager.h"
-#include "../data/skin.h"
+// #include "../data/skin.h"
+#include "../models/skin.h"
 
 
 // * SkinManager: Manages loading, storing, and accessing skins


### PR DESCRIPTION
This pull request refactors the codebase to introduce dedicated model classes for beatmaps and skins, separating them from their data structures. It updates the beatmap and skin management logic to use these new models, improving code organization and maintainability. Additionally, it makes minor improvements to comments, build scripts, and directory includes.

**Core architecture changes:**

* Introduced `Beatmap` and `Skin` model classes in `src/models/beatmap.h`, `src/models/beatmap.cpp`, and `src/models/skin.h`, encapsulating instance-specific logic and metadata, and moved lifecycle management to these models. [[1]](diffhunk://#diff-5312d761bb78ada246b754adcd690a165cf92585248480634567e3abf25a2663R1-R48) [[2]](diffhunk://#diff-6b0a61ce6a9a044a710c7f4a19c06be945a8b344a245413ff339c6458903d561R1-R28) [[3]](diffhunk://#diff-e1688cdc3595fbbe99563ee38f7ba309f50c0a40b8082b34db5f2aad32de462aR1-R36)
* Refactored `BeatmapManager` and `SkinManager` to use the new model classes instead of directly using data structs or parser classes. This affects member types, function signatures, and internal logic in `src/state/beatmap.h`, `src/state/beatmap.cpp`, and `src/state/skin.h`. [[1]](diffhunk://#diff-809b2a3427088a59b160e7c0fc033509d0113043943548214386d63b46396755L11-R11) [[2]](diffhunk://#diff-809b2a3427088a59b160e7c0fc033509d0113043943548214386d63b46396755L21-R29) [[3]](diffhunk://#diff-809b2a3427088a59b160e7c0fc033509d0113043943548214386d63b46396755L47-R47) [[4]](diffhunk://#diff-ac1043e63c4e08111080f4930b8fda05f1bf83be0817a4015484ba579d2eb8e2L143-R146) [[5]](diffhunk://#diff-ac1043e63c4e08111080f4930b8fda05f1bf83be0817a4015484ba579d2eb8e2L169-R172) [[6]](diffhunk://#diff-ac1043e63c4e08111080f4930b8fda05f1bf83be0817a4015484ba579d2eb8e2R196-R199) [[7]](diffhunk://#diff-ac1043e63c4e08111080f4930b8fda05f1bf83be0817a4015484ba579d2eb8e2L207-L215) [[8]](diffhunk://#diff-2af98db87916b7bf1c836c3884fde435009e203c8b7e6d71d7b7ced77f65a282L4-R5)
* Removed the old `Skin` class definition from `src/data/skin.h` now that the model class exists in `src/models/skin.h`.

**Data structure and logic improvements:**

* Updated `BeatmapExData` to store only minimal necessary information, including the audio filename, and improved documentation/comments. Added a TODO to optimize audio path handling. [[1]](diffhunk://#diff-07dce18b875ff9517b813108f1a3f259f1d4576eb0714d7540b9be7ef8e8b83dL12-R20) [[2]](diffhunk://#diff-6b0a61ce6a9a044a710c7f4a19c06be945a8b344a245413ff339c6458903d561R1-R28)
* Improved comments and added documentation to clarify initialization guarantees in skin data structures.

**Build and infrastructure:**

* Added `src/models` to the include directories in `CMakeLists.txt` to support the new model files.
* Improved messaging in the `compile` script for clarity.